### PR TITLE
OGM-1469 Fix in field type resolution for associations / embedded properties

### DIFF
--- a/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/test/cfg/ConfigWithAssociationsAndEmbeddedTest.java
+++ b/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/test/cfg/ConfigWithAssociationsAndEmbeddedTest.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.ignite.test.cfg;
+
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+import org.hibernate.ogm.OgmSession;
+import org.hibernate.ogm.OgmSessionFactory;
+import org.hibernate.ogm.backendtck.associations.manytoone.Court;
+import org.hibernate.ogm.backendtck.associations.manytoone.Game;
+import org.hibernate.ogm.datastore.ignite.utils.IgniteTestHelper;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.junit.Test;
+
+/**
+ * @author Aliaksandr Salauyou
+ */
+public class ConfigWithAssociationsAndEmbeddedTest extends OgmTestCase {
+
+	static final String STRING_TYPE = "java.lang.String";
+	static final String INT_TYPE = "java.lang.Integer";
+
+	@Test
+	public void testCacheConfig() {
+		try ( OgmSession session = openSession() ) {
+			OgmSessionFactory sf = session.getSessionFactory();
+
+			Map<String, String> fields = IgniteTestHelper.getFields( sf, Court.class );
+			assertThat( fields.get( "id_countryCode" ) ).isEqualTo( STRING_TYPE );
+			assertThat( fields.get( "id_sequenceNo" ) ).isEqualTo( INT_TYPE );
+			assertThat( fields.get( "name" ) ).isEqualTo( STRING_TYPE );
+			assertThat( fields.get( "playedOn" ) ).isNull();
+
+			fields = IgniteTestHelper.getFields( sf, Game.class );
+			assertThat( fields.get( "id_category" ) ).isEqualTo( STRING_TYPE );
+			assertThat( fields.get( "id_gameSequenceNo" ) ).isEqualTo( INT_TYPE );
+			assertThat( fields.get( "name" ) ).isEqualTo( STRING_TYPE );
+			assertThat( fields.get( "playedOn_id_countryCode" ) ).isEqualTo( STRING_TYPE );
+			assertThat( fields.get( "playedOn_id_sequenceNo" ) ).isEqualTo( INT_TYPE );
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Court.class, Game.class };
+	}
+}

--- a/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/utils/IgniteTestHelper.java
+++ b/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/utils/IgniteTestHelper.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -215,14 +216,26 @@ public class IgniteTestHelper implements GridDialectTestHelper {
 	public void prepareDatabase(SessionFactory arg0) {
 	}
 
-	public static Set<QueryIndex> getIndexes(OgmSessionFactory sessionFactory, Class<?> entityClass) {
-		Set<QueryIndex> result = new HashSet<>();
-		Map<String, EntityPersister> m = ( (SessionFactoryImplementor) sessionFactory ).getEntityPersisters();
+	private static CacheConfiguration getCacheConfiguration(OgmSessionFactory sessionFactory, Class<?> entityClass) {
 		OgmEntityPersister entityPersister = (OgmEntityPersister) ( (SessionFactoryImplementor) sessionFactory ).locateEntityPersister( entityClass );
 		IgniteCache<Object, BinaryObject> cache = getProvider( sessionFactory ).getEntityCache( entityPersister.getEntityKeyMetadata() );
-		CacheConfiguration<Object, BinaryObject> cacheConfig = cache.getConfiguration( CacheConfiguration.class );
+		return cache.getConfiguration( CacheConfiguration.class );
+	}
+
+	public static Set<QueryIndex> getIndexes(OgmSessionFactory sessionFactory, Class<?> entityClass) {
+		Set<QueryIndex> result = new HashSet<>();
+		CacheConfiguration<Object, BinaryObject> cacheConfig = getCacheConfiguration( sessionFactory, entityClass );
 		for ( QueryEntity queryEntity : cacheConfig.getQueryEntities() ) {
 			result.addAll( queryEntity.getIndexes() );
+		}
+		return result;
+	}
+
+	public static Map<String, String> getFields(OgmSessionFactory sessionFactory, Class<?> entityClass) {
+		Map<String, String> result = new LinkedHashMap<>();
+		CacheConfiguration<Object, BinaryObject> cacheConfig = getCacheConfiguration( sessionFactory, entityClass );
+		for ( QueryEntity queryEntity : cacheConfig.getQueryEntities() ) {
+			result.putAll( queryEntity.getFields() );
 		}
 		return result;
 	}

--- a/ignite/src/test/resources/skipTests
+++ b/ignite/src/test/resources/skipTests
@@ -14,7 +14,8 @@ org.hibernate.ogm.backendtck.optimisticlocking.OptimisticLockingTest#updatingEnt
 org.hibernate.ogm.backendtck.queries.CompositeIdQueriesTest
 org.hibernate.ogm.backendtck.queries.QueriesWithAssociationsTest
 org.hibernate.ogm.backendtck.queries.QueriesWithEmbeddedCollectionTest
-org.hibernate.ogm.backendtck.queries.QueriesWithEmbeddedTest
+org.hibernate.ogm.backendtck.queries.QueriesWithEmbeddedTest#testQueryWithEmbeddablePropertyInSelectClauseWithOneResult
+org.hibernate.ogm.backendtck.queries.QueriesWithEmbeddedTest#testQueryWithEmbeddablePropertyInSelectClause
 org.hibernate.ogm.backendtck.queries.SimpleQueriesTest#testInQueryOnAssociatedEntity
 org.hibernate.ogm.backendtck.queries.SimpleQueriesTest#testIsNotNullQueryOnAssociatedEntity
 org.hibernate.ogm.backendtck.queries.SimpleQueriesTest#testIsNullQueryOnPropertyOfAssociatedEntity


### PR DESCRIPTION
- if a column holds association key, its type should be set to associated entity key type (currently, it is wrongly resolved as associated entity class in *-to-one and java.util.String in many-to-many join tables)
- if a column holds part of embedded property, its type should be set to actual type of that part (currently resolved as embeded property class itself)
