### PR TITLE
use an index name that is guaranteed to be no more than 255 chars

### DIFF
--- a/ignite/src/main/java/org/hibernate/ogm/datastore/ignite/impl/IgniteCacheInitializer.java
+++ b/ignite/src/main/java/org/hibernate/ogm/datastore/ignite/impl/IgniteCacheInitializer.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.apache.ignite.cache.CacheAtomicityMode;
 import org.apache.ignite.cache.QueryEntity;
@@ -180,7 +181,7 @@ public class IgniteCacheInitializer extends BaseSchemaDefiner {
 			fields.put( realColumnName, true );
 		}
 		queryIndex.setFields( fields );
-		queryIndex.setName( queryEntity.getTableName() + '_' + org.hibernate.ogm.util.impl.StringHelper.join( fields.keySet(), "_" ) );
+		queryIndex.setName( UUID.randomUUID().toString().replace( "-", "_" ) );
 
 		Set<QueryIndex> indexes = new HashSet<>( queryEntity.getIndexes() );
 		indexes.add( queryIndex );

--- a/ignite/src/main/java/org/hibernate/ogm/datastore/ignite/impl/IgniteCacheInitializer.java
+++ b/ignite/src/main/java/org/hibernate/ogm/datastore/ignite/impl/IgniteCacheInitializer.java
@@ -181,19 +181,19 @@ public class IgniteCacheInitializer extends BaseSchemaDefiner {
 			fields.put( realColumnName, true );
 		}
 		queryIndex.setFields( fields );
-		String indexName = queryEntity.getTableName() + '_' + org.hibernate.ogm.util.impl.StringHelper.join( fields.keySet(), "_" );
+		String indexName = queryEntity.getTableName() + '_' + UUID.nameUUIDFromBytes( org.hibernate.ogm.util.impl.StringHelper.join( fields.keySet(), "_" ).getBytes() );
 		Class<?> tableClass = context.getTableEntityTypeMapping().get( associationKeyMetadata.getAssociatedEntityKeyMetadata().getEntityKeyMetadata().getTable() );
 		javax.persistence.Table tableAnnotation = tableClass.getAnnotation( javax.persistence.Table.class );
-		if( tableAnnotation != null && tableAnnotation.indexes().length > 0) {
-			for(javax.persistence.Index index: tableAnnotation.indexes()){
-				if(!index.name().isEmpty()) {
+		if ( tableAnnotation != null && tableAnnotation.indexes().length > 0 ) {
+			for ( javax.persistence.Index index: tableAnnotation.indexes() ) {
+				if ( !index.name().isEmpty() ) {
 					indexName = index.name();
 					break;
 				}
 			}
 		}
 		if ( indexName.getBytes().length > 255 ) {
-			throw log.indexNameTooLong(indexName, queryEntity.getTableName());
+			throw log.indexNameTooLong( indexName, queryEntity.getTableName() );
 		}
 		queryIndex.setName( indexName );
 

--- a/ignite/src/main/java/org/hibernate/ogm/datastore/ignite/logging/impl/Log.java
+++ b/ignite/src/main/java/org/hibernate/ogm/datastore/ignite/logging/impl/Log.java
@@ -49,4 +49,7 @@ public interface Log extends org.hibernate.ogm.util.impl.Log {
 
 	@Message(id = 1710, value = "Neither " + IgniteProperties.CONFIGURATION_RESOURCE_NAME + " nor " + IgniteProperties.CONFIGURATION_CLASS_NAME + " properties are set")
 	HibernateException configurationNotSet();
+
+	@Message(id = 1711, value = "Invalid index name '%s' for entity '%s'. It must not be longer than 255 bytes. Use javax.persistence.@Index to override")
+	HibernateException indexNameTooLong(String indexName, String entityName);
 }

--- a/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/test/cfg/LongIndexNameTest.java
+++ b/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/test/cfg/LongIndexNameTest.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.ignite.test.cfg;
+
+import org.hibernate.HibernateException;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.junit.Test;
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+import static org.junit.Assert.*;
+
+/**
+ * Entities with long names that results in an index with greater than 255 chars is invalid in Ignite.
+ * This ensures we raise an error and provide useful information to the user
+ */
+public class LongIndexNameTest extends OgmTestCase {
+
+	@Test(expected = HibernateException.class)
+	public void testLongEntityIndexName() throws Exception {
+		fail("The length of the registered entity's cache name should've failed this already");
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				LongEntityName.class,
+				LongEntityContainer.class
+		};
+	}
+
+	@Entity
+	public static class LongEntityContainer {
+		@Id
+		private String id;
+
+		@OneToMany(targetEntity = LongEntityName.class)
+		private Set<LongEntityName> longEntityNames = new HashSet<>();
+
+		@javax.persistence.JoinTable(name = "joinLongEntityName")
+		public Set<LongEntityName> getLongEntityNames() {
+			return longEntityNames;
+		}
+	}
+
+	@Entity(name = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec dapibus cursus vestibulum. Quisque eu justo non mi tincidunt sagittis. Donec tincidunt facilisis placerat. Sed placerat urna eget tristique faucibus. Curabitur maximus gravida enim, vitae sed")
+	public static class LongEntityName {
+		@Id
+		private String id;
+	}
+}

--- a/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/test/cfg/LongIndexNameTest.java
+++ b/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/test/cfg/LongIndexNameTest.java
@@ -9,10 +9,14 @@ package org.hibernate.ogm.datastore.ignite.test.cfg;
 import org.hibernate.HibernateException;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.junit.Test;
-import javax.persistence.*;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import java.util.HashSet;
 import java.util.Set;
-import static org.junit.Assert.*;
+
+import static junit.framework.TestCase.fail;
 
 /**
  * Entities with long names that results in an index with greater than 255 chars is invalid in Ignite.
@@ -22,7 +26,7 @@ public class LongIndexNameTest extends OgmTestCase {
 
 	@Test(expected = HibernateException.class)
 	public void testLongEntityIndexName() throws Exception {
-		fail("The length of the registered entity's cache name should've failed this already");
+		fail( "The length of the registered entity's cache name should've failed this already" );
 	}
 
 	@Override

--- a/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/test/cfg/LongIndexNameWithIndexAnnotationTest.java
+++ b/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/test/cfg/LongIndexNameWithIndexAnnotationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.ogm.datastore.ignite.test.cfg;
+
+import org.apache.ignite.cache.QueryIndex;
+import org.hibernate.HibernateException;
+import org.hibernate.ogm.OgmSession;
+import org.hibernate.ogm.datastore.ignite.utils.IgniteTestHelper;
+import org.hibernate.ogm.utils.OgmTestCase;
+import org.junit.Test;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Entities with long names that results in an index with greater than 255 chars is invalid in Ignite.
+ * This ensures we raise an error and provide useful information to the user
+ */
+public class LongIndexNameWithIndexAnnotationTest extends OgmTestCase {
+
+	@Test
+	public void testLongEntityIndexName() throws Exception {
+		try ( OgmSession session = openSession() ) {
+			Set<QueryIndex> indexes = IgniteTestHelper.getIndexes( session.getSessionFactory(), EntityWithCustomIndex.class );
+			assertThat( indexes.size() ).isEqualTo( 1 );
+			assertThat( indexes.iterator().next().getName() ).isEqualToIgnoringCase( "SimpleIndexName" );
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				EntityWithCustomIndex.class,
+				EntityWithCustomContainer.class
+		};
+	}
+
+	@Entity
+	public static class EntityWithCustomContainer {
+		@Id
+		private String id;
+
+		@OneToMany(targetEntity = EntityWithCustomIndex.class)
+		private Set<EntityWithCustomIndex> entityWithCustomIndices = new HashSet<>();
+
+		@javax.persistence.JoinTable(name = "joinLongEntityName")
+		public Set<EntityWithCustomIndex> getEntityWithCustomIndices() {
+			return entityWithCustomIndices;
+		}
+	}
+
+	@Entity(name = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec dapibus cursus vestibulum. Quisque eu justo non mi tincidunt sagittis. Donec tincidunt facilisis placerat. Sed placerat urna eget tristique faucibus. Curabitur maximus gravida enim, vitae sed")
+	@Table(indexes = {@Index(name = "SimpleIndexName", columnList = "id")})
+	public static class EntityWithCustomIndex {
+		@Id
+		private String id;
+	}
+}

--- a/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/test/cfg/LongIndexNameWithIndexAnnotationTest.java
+++ b/ignite/src/test/java/org/hibernate/ogm/datastore/ignite/test/cfg/LongIndexNameWithIndexAnnotationTest.java
@@ -7,18 +7,20 @@
 package org.hibernate.ogm.datastore.ignite.test.cfg;
 
 import org.apache.ignite.cache.QueryIndex;
-import org.hibernate.HibernateException;
 import org.hibernate.ogm.OgmSession;
 import org.hibernate.ogm.datastore.ignite.utils.IgniteTestHelper;
 import org.hibernate.ogm.utils.OgmTestCase;
 import org.junit.Test;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.util.HashSet;
 import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * Entities with long names that results in an index with greater than 255 chars is invalid in Ignite.


### PR DESCRIPTION
Ignite indices have a char limit of 255 on the name.
The current naming scheme easily exceeds that in complex models because it uses the field names on the entity. 
This PR uses a random UUID instead, ensuring that limit is never hit.
I considered using "tableName + UUID" but that just makes it less likely since it's possible to have entity names longer than the 127 chars that the UUID leaves us with.

For reference an example of the current scheme failing manifests itself as in the attached file/stacktrace.
[ignite-ogm-index-name-error.txt](https://github.com/hibernate/hibernate-ogm-ignite/files/2151458/ignite-ogm-index-name-error.txt)
